### PR TITLE
Fix "Undefined" for field with maximum brightness

### DIFF
--- a/image-converter.js
+++ b/image-converter.js
@@ -69,7 +69,7 @@ function getStr(arr){
     let str = '';
     arr.forEach(row => {
         row.forEach(col => {
-            for(let i = symbols.length - 1; i >= 0; i--){
+            for(let i = symbols.length - 2; i >= 0; i--){
                 if(col >= symbols[i].val){
                     str += `<span class="point">${symbols[i].symbol}</span>`;
                     break;


### PR DESCRIPTION
All further info can be found in #2 
This fixes #2

But why has this not occured during testing? I think the reason is that there is an integer division in line 86 and in some cases the last step is actually lower than the brightness of the cell. This isn't necessarily a problem (at least in imags with high contrast i think??) because it can be fixed with the proposed changes. Why complain about the wrong math when you can just fix the bug that has a problem with it?
 